### PR TITLE
feat: (#40) 댓글 목록 조회 API 응답 개선

### DIFF
--- a/app/src/common/middleware/authMiddleware.js
+++ b/app/src/common/middleware/authMiddleware.js
@@ -19,6 +19,7 @@ const requireAuth = (req, res, next) => {
     return res.status(401).json({ message: "유효하지 않은 토큰입니다." });
   }
 };
+
 const optionalAuth = (req, res, next) => {
   const bearerToken = req.headers.authorization;
 

--- a/app/src/repositories/comment/commentRepository.js
+++ b/app/src/repositories/comment/commentRepository.js
@@ -99,10 +99,11 @@ class CommentRepository {
 
   async getCommentsByEpisode(episodeId) {
     const query = `
-      SELECT *
-      FROM comments
-      WHERE episode_id = ?
-      ORDER BY created_at ASC;
+      SELECT c.*, u.username, u.nickname
+      FROM comments c
+      JOIN users u ON c.user_id = u.id
+      WHERE c.episode_id = ?
+      ORDER BY c.created_at ASC;
     `;
     const [rows] = await pool.query(query, [episodeId]);
     return toCamelCase(rows);

--- a/app/src/routes/comment/commentController.js
+++ b/app/src/routes/comment/commentController.js
@@ -66,7 +66,9 @@ module.exports = {
 
   getCommentsByEpisode: async (req, res) => {
     const { episodeId } = req.params;
-    const comments = await commentService.getCommentsByEpisode(episodeId);
+    const userId = req.user?.id || null;
+
+    const comments = await commentService.getCommentsByEpisode(episodeId, userId);
     return res.status(200).json({
       success: true,
       data: {

--- a/app/src/routes/home/index.js
+++ b/app/src/routes/home/index.js
@@ -20,7 +20,6 @@ const userValidation = require("@validation/user/userValidation.js");
 const favoriteValidation = require("@validation/favorite/favoriteValidation.js");
 const { requireAuth, optionalAuth } = require("@middleware/authMiddleware.js");
 
-
 // 인증(Authentication) API
 router.post("/api/auth/signup", authValidation.checkAddUser, authCtrl.signUp);
 router.post("/api/auth/login", authValidation.checkUser, authCtrl.login);
@@ -91,11 +90,12 @@ router.put(
 );
 router.get(
   "/api/episodes/:episodeId/comments",
+  optionalAuth,
   commentValidation.checkEpisodeIdParam,
   commentCtrl.getCommentsByEpisode
 );
 
-// 마이페이지 API
+// User API
 router.get("/api/users/me", requireAuth, userCtrl.getMyInfo);
 router.patch(
   "/api/users/me/nickname",


### PR DESCRIPTION
## 연관된 이슈
- #40

## 📝 작업 내용
- [x]  전체 댓글 `개수(count)` 반환
- [x] 각 댓글 `작성자(user)` 정보 포함
- [x] 로그인/비로그인 사용자별 `댓글 반응` 정보 포함
- 좋아요/싫어요 총 개수
- 로그인 사용자라면 본인의 반응(userReaction) 포함