### PR TITLE
refactor: (#47) repository 트랜잭션 처리 형식 통일 및 getDb 적용

### DIFF
--- a/app/src/common/utils/getDb.js
+++ b/app/src/common/utils/getDb.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const pool = require("@config/db");
+
+/**
+ * DB 연결 객체 반환
+ *
+ * 전달된 연결 객체(conn)가 있으면 사용하고, 없으면 기본 pool 반환
+ * repository에서 트랜잭션 적용 등 유연한 DB 연결에 활용됨
+ *
+ * @param {Object} conn - 이미 생성된 MySQL 연결 객체 (선택)
+ * @returns {Object} - 사용할 DB 연결(pool 또는 전달된 conn)
+ */
+function getDb(conn) {
+  return conn ?? pool;
+}
+
+module.exports = getDb;

--- a/app/src/repositories/comment/commentRepository.js
+++ b/app/src/repositories/comment/commentRepository.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const getDb = require("@utils/getDb.js");
-const toCamelCase = require("@utils/toCamelCase.js");
+const getDb = require("@utils/getDb");
+const toCamelCase = require("@utils/toCamelCase");
 
 class CommentRepository {
   async findById(commentId, conn) {

--- a/app/src/repositories/comment/commentRepository.js
+++ b/app/src/repositories/comment/commentRepository.js
@@ -1,86 +1,95 @@
 "use strict";
 
-const pool = require("@config/db");
+const getDb = require("@utils/getDb.js");
 const toCamelCase = require("@utils/toCamelCase.js");
 
 class CommentRepository {
-  async findById(commentId) {
+  async findById(commentId, conn) {
+    const db = getDb(conn);
     const query = `
       SELECT * 
       FROM comments 
       WHERE id = ?;
     `;
-    const [rows] = await pool.query(query, [commentId]);
+    const [rows] = await db.query(query, [commentId]);
     return toCamelCase(rows[0]);
   }
 
-  async createComment({ episodeId, userId, content, parentId }) {
+  async createComment({ episodeId, userId, content, parentId }, conn) {
+    const db = getDb(conn);
     const query = `
       INSERT INTO comments (episode_id, user_id, content, parent_id) 
       VALUES (?, ?, ?, ?);
     `;
-    const [result] = await pool.query(query, [episodeId, userId, content, parentId]);
+    const [result] = await db.query(query, [episodeId, userId, content, parentId]);
 
     const newComment = await this.findById(result.insertId);
     return newComment;
   }
 
-  async updateComment(commentId, { content }) {
+  async updateComment(commentId, { content }, conn) {
+    const db = getDb(conn);
     const query = `
       UPDATE comments
       SET content = ?
       WHERE id = ?;
     `;
-    await pool.query(query, [content, commentId]);
+    await db.query(query, [content, commentId]);
 
     const updatedComment = await this.findById(commentId);
     return updatedComment;
   }
 
-  async deleteComment(commentId) {
+  async deleteComment(commentId, conn) {
+    const db = getDb(conn);
     const query = `
       DELETE FROM comments
       WHERE id = ?;
     `;
-    await pool.query(query, [commentId]);
+    await db.query(query, [commentId]);
   }
 
-  async findReaction(commentId, userId) {
+  async findReaction(commentId, userId, conn) {
+    const db = getDb(conn);
     const query = `
       SELECT * 
       FROM comment_reactions
       WHERE comment_id = ? AND user_id = ?;
     `;
-    const [rows] = await pool.query(query, [commentId, userId]);
+    const [rows] = await db.query(query, [commentId, userId]);
     return toCamelCase(rows[0]);
   }
 
-  async createReaction(commentId, userId, type) {
+  async createReaction(commentId, userId, type, conn) {
+    const db = getDb(conn);
     const query = `
       INSERT INTO comment_reactions (comment_id, user_id, reaction_type)
       VALUES (?, ?, ?);
     `;
-    await pool.query(query, [commentId, userId, type]);
+    await db.query(query, [commentId, userId, type]);
   }
 
-  async updateReaction(commentId, userId, type) {
+  async updateReaction(commentId, userId, type, conn) {
+    const db = getDb(conn);
     const query = `
       UPDATE comment_reactions
       SET reaction_type = ?, updated_at = CURRENT_TIMESTAMP
       WHERE comment_id = ? AND user_id = ?;
     `;
-    await pool.query(query, [type, commentId, userId]);
+    await db.query(query, [type, commentId, userId]);
   }
 
-  async deleteReaction(commentId, userId) {
+  async deleteReaction(commentId, userId, conn) {
+    const db = getDb(conn);
     const query = `
       DELETE FROM comment_reactions
       WHERE comment_id = ? AND user_id = ?;
     `;
-    await pool.query(query, [commentId, userId]);
+    await db.query(query, [commentId, userId]);
   }
 
-  async countReactions(commentId) {
+  async countReactions(commentId, conn) {
+    const db = getDb(conn);
     const query = `
       SELECT 
         SUM(reaction_type = 'like') AS like_count,
@@ -88,7 +97,7 @@ class CommentRepository {
       FROM comment_reactions
       WHERE comment_id = ?;
     `;
-    const [rows] = await pool.query(query, [commentId]);
+    const [rows] = await db.query(query, [commentId]);
     const result = toCamelCase(rows[0]);
 
     return {
@@ -97,14 +106,15 @@ class CommentRepository {
     };
   }
 
-  async getCommentsByEpisode(episodeId) {
+  async getCommentsByEpisode(episodeId, conn) {
+    const db = getDb(conn);
     const query = `
       SELECT *
       FROM comments
       WHERE episode_id = ?
       ORDER BY created_at ASC;
     `;
-    const [rows] = await pool.query(query, [episodeId]);
+    const [rows] = await db.query(query, [episodeId]);
     return toCamelCase(rows);
   }
 }

--- a/app/src/repositories/favorite/favoriteRepository.js
+++ b/app/src/repositories/favorite/favoriteRepository.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const getDb = require("@utils/getDb.js");
-const toCamelCase = require("@utils/toCamelCase.js");
+const getDb = require("@utils/getDb");
+const toCamelCase = require("@utils/toCamelCase");
 
 class FavoriteRepository {
   static ALLOWED_SORTS = {

--- a/app/src/repositories/user/userRepository.js
+++ b/app/src/repositories/user/userRepository.js
@@ -1,67 +1,73 @@
 "use strict";
 
-const pool = require("@config/db");
+const getDb = require("@utils/getDb.js");
 const toCamelCase = require("@utils/toCamelCase.js");
 
 class UserRepository {
-  async findById(userId) {
+  async findById(userId, conn) {
+    const db = getDb(conn);
     const query = `
       SELECT *
       FROM users
       WHERE id = ?;
     `;
-    const [rows] = await pool.query(query, [userId]);
+    const [rows] = await db.query(query, [userId]);
     return rows.length ? toCamelCase(rows[0]) : null;
   }
 
-  async findByUsername(username) {
+  async findByUsername(username, conn) {
+    const db = getDb(conn);
     const query = `
       SELECT * 
       FROM users 
       WHERE username = ?;
     `;
-    const [rows] = await pool.query(query, [username]);
+    const [rows] = await db.query(query, [username]);
     return rows[0];
   }
 
-  async findByNickname(nickname) {
+  async findByNickname(nickname, conn) {
+    const db = getDb(conn);
     const query = `
       SELECT * 
       FROM users 
       WHERE nickname = ?;
     `;
-    const [rows] = await pool.query(query, [nickname]);
+    const [rows] = await db.query(query, [nickname]);
     return rows[0];
   }
 
-  async createUser({ username, password, nickname }) {
+  async createUser({ username, password, nickname }, conn) {
+    const db = getDb(conn);
     const query = `
       INSERT INTO users (username, password, nickname) 
       VALUES (?, ?, ?);
     `;
-    const [result] = await pool.query(query, [username, password, nickname]);
+    const [result] = await db.query(query, [username, password, nickname]);
 
     const userId = result.insertId;
     return await this.findById(userId);
   }
 
-  async updateNickname(userId, newNickname) {
+  async updateNickname(userId, newNickname, conn) {
+    const db = getDb(conn);
     const query = `
       UPDATE users
       SET nickname = ?
       WHERE id = ?;
     `;
-    const [result] = await pool.query(query, [newNickname, userId]);
+    const [result] = await db.query(query, [newNickname, userId]);
     return result.affectedRows === 1;
   }
 
-  async updatePassword(userId, hashedPassword) {
+  async updatePassword(userId, hashedPassword, conn) {
+    const db = getDb(conn);
     const query = `
       UPDATE users
       SET password = ?
       WHERE id = ?;
     `;
-    const [result] = await pool.query(query, [hashedPassword, userId]);
+    const [result] = await db.query(query, [hashedPassword, userId]);
     return result.affectedRows === 1;
   }
 }

--- a/app/src/repositories/user/userRepository.js
+++ b/app/src/repositories/user/userRepository.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const getDb = require("@utils/getDb.js");
-const toCamelCase = require("@utils/toCamelCase.js");
+const getDb = require("@utils/getDb");
+const toCamelCase = require("@utils/toCamelCase");
 
 class UserRepository {
   async findById(userId, conn) {

--- a/app/src/repositories/webtoon/episodeRepository.js
+++ b/app/src/repositories/webtoon/episodeRepository.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const getDb = require("@utils/getDb.js");
-const toCamelCase = require("@utils/toCamelCase.js");
+const getDb = require("@utils/getDb");
+const toCamelCase = require("@utils/toCamelCase");
 
 class EpisodeRepository {
   // 웹툰에 맞는 전체 회차 불러오기

--- a/app/src/repositories/webtoon/episodeRepository.js
+++ b/app/src/repositories/webtoon/episodeRepository.js
@@ -1,11 +1,12 @@
 "use strict";
 
-const pool = require("@config/db");
+const getDb = require("@utils/getDb.js");
 const toCamelCase = require("@utils/toCamelCase.js");
 
 class EpisodeRepository {
   // 웹툰에 맞는 전체 회차 불러오기
-  async getEpisodesByWebtoonId(webtoonId) {
+  async getEpisodesByWebtoonId(webtoonId, conn) {
+    const db = getDb(conn);
     const query = `
         SELECT
           ep.id,
@@ -18,12 +19,13 @@ class EpisodeRepository {
         WHERE ep.webtoon_id = ?
         ORDER BY ep.episode_no ASC;
       `;
-    const [rows] = await pool.query(query, [webtoonId]);
+    const [rows] = await db.query(query, [webtoonId]);
     return toCamelCase(rows);
   }
 
   // 회차클릭 후 만화 불러오기
-  async getEpisodeDetailById(episodeId, userId) {
+  async getEpisodeDetailById(episodeId, userId, conn) {
+    const db = getDb(conn);
     let query, params;
     if (!userId) {
       // 비로그인
@@ -62,21 +64,23 @@ class EpisodeRepository {
     `;
       params = [userId, episodeId];
     }
-    const [rows] = await pool.query(query, params);
+    const [rows] = await db.query(query, params);
     return toCamelCase(rows[0]);
   }
 
   // 별점 등록
-  async createRating(conn, userId, episodeId, rating) {
+  async createRating(userId, episodeId, rating, conn) {
+    const db = getDb(conn);
     const query = `
       INSERT INTO ratings (user_id, episode_id, rating)
       VALUES (?, ?, ?);
     `;
-    const [res] = await conn.query(query, [userId, episodeId, rating]);
+    const [res] = await db.query(query, [userId, episodeId, rating]);
     return res;
   }
 
-  async applyNewRating(conn, episodeId, rating) {
+  async applyNewRating(episodeId, rating, conn) {
+    const db = getDb(conn);
     const updateQuery = `
       UPDATE episodes
       SET
@@ -85,7 +89,7 @@ class EpisodeRepository {
         rating_avg = ROUND((rating_sum) / (rating_count), 2)
       WHERE id = ?;
     `;
-    const [res] = await conn.query(updateQuery, [rating, episodeId]);
+    const [res] = await db.query(updateQuery, [rating, episodeId]);
     if (res.affectedRows === 0) return null;
 
     const selectQuery = `
@@ -95,7 +99,7 @@ class EpisodeRepository {
     FROM episodes
     WHERE id = ?;
   `;
-    const [rows] = await conn.query(selectQuery, [episodeId]);
+    const [rows] = await db.query(selectQuery, [episodeId]);
     return toCamelCase(rows[0]);
   }
 }

--- a/app/src/repositories/webtoon/webtoonRepository.js
+++ b/app/src/repositories/webtoon/webtoonRepository.js
@@ -1,11 +1,12 @@
 "use strict";
 
-const pool = require("@config/db");
+const getDb = require("@utils/getDb.js");
 const toCamelCase = require("@utils/toCamelCase.js");
 
 class WebtoonRepository {
   // 요일 기준 정렬 조회
-  async getWebtoonsByDaySorted(day, sort) {
+  async getWebtoonsByDaySorted(day, sort, conn) {
+    const db = getDb(conn);
     let query;
     if (sort === "rating_avg") {
       query = `
@@ -40,11 +41,12 @@ class WebtoonRepository {
         ORDER BY wt.${sort} DESC;
       `;
     }
-    const [rows] = await pool.query(query, [day]);
+    const [rows] = await db.query(query, [day]);
     return toCamelCase(rows);
   }
   // 정렬 조건 기준 전체 조회
-  async getAllWebtoonsSorted(sort) {
+  async getAllWebtoonsSorted(sort, conn) {
+    const db = getDb(conn);
     let query;
     if (sort === "rating_avg") {
       query = `
@@ -75,11 +77,12 @@ class WebtoonRepository {
       ORDER BY wt.${sort} DESC;
     `;
     }
-    const [rows] = await pool.query(query);
+    const [rows] = await db.query(query);
     return toCamelCase(rows);
   }
   // 웹툰 상세 정보 불러오기
-  async getWebtoonById(webtoonId) {
+  async getWebtoonById(webtoonId, conn) {
+    const db = getDb(conn);
     const query = `
       SELECT 
         wt.id, 
@@ -97,17 +100,18 @@ class WebtoonRepository {
       WHERE wt.id = ?
       GROUP BY wt.id;
     `;
-    const [rows] = await pool.query(query, [webtoonId]);
+    const [rows] = await db.query(query, [webtoonId]);
     return toCamelCase(rows[0]);
   }
 
   async updateFavoriteCount(webtoonId, increment, conn) {
+    const db = getDb(conn);
     const query = `
       UPDATE webtoons
       SET favorite_count = favorite_count + ?
       WHERE id = ?;
     `;
-    await conn.query(query, [increment, webtoonId]);
+    await db.query(query, [increment, webtoonId]);
   }
 }
 

--- a/app/src/repositories/webtoon/webtoonRepository.js
+++ b/app/src/repositories/webtoon/webtoonRepository.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const getDb = require("@utils/getDb.js");
-const toCamelCase = require("@utils/toCamelCase.js");
+const getDb = require("@utils/getDb");
+const toCamelCase = require("@utils/toCamelCase");
 
 class WebtoonRepository {
   // 요일 기준 정렬 조회

--- a/app/src/routes/auth/authController.js
+++ b/app/src/routes/auth/authController.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const AuthService = require("@services/auth/authService.js");
-const { setRefreshToken, clearRefreshToken } = require("@utils/cookie.js");
+const AuthService = require("@services/auth/authService");
+const { setRefreshToken, clearRefreshToken } = require("@utils/cookie");
 const authService = new AuthService();
 function handleRefreshToken(res, data) {
   if (data.refreshToken) {

--- a/app/src/routes/comment/commentController.js
+++ b/app/src/routes/comment/commentController.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const CommentService = require("@services/comment/commentService.js");
+const CommentService = require("@services/comment/commentService");
 const commentService = new CommentService();
 
 module.exports = {

--- a/app/src/routes/favorite/favoriteController.js
+++ b/app/src/routes/favorite/favoriteController.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const FavoriteService = require("@services/favorite/favoriteService.js");
+const FavoriteService = require("@services/favorite/favoriteService");
 const favoriteService = new FavoriteService();
 
 module.exports = {

--- a/app/src/routes/home/index.js
+++ b/app/src/routes/home/index.js
@@ -4,21 +4,21 @@ const express = require("express");
 const router = express.Router();
 
 // 컨트롤러
-const authCtrl = require("@routes/auth/authController.js");
-const webtoonCtrl = require("@routes/webtoon/webtoonController.js");
-const episodeCtrl = require("@routes/webtoon/episodeController.js");
-const commentCtrl = require("@routes/comment/commentController.js");
-const userCtrl = require("@routes/user/userController.js");
-const favoriteCtrl = require("@routes/favorite/favoriteController.js");
+const authCtrl = require("@routes/auth/authController");
+const webtoonCtrl = require("@routes/webtoon/webtoonController");
+const episodeCtrl = require("@routes/webtoon/episodeController");
+const commentCtrl = require("@routes/comment/commentController");
+const userCtrl = require("@routes/user/userController");
+const favoriteCtrl = require("@routes/favorite/favoriteController");
 
 // 미들웨어
-const authValidation = require("@validation/auth/authValidation.js");
-const webtoonValidation = require("@validation/webtoon/webtoonValidation.js");
-const episodeValidation = require("@validation/webtoon/episodeValidation.js");
-const commentValidation = require("@validation/comment/commentValidation.js");
-const userValidation = require("@validation/user/userValidation.js");
-const favoriteValidation = require("@validation/favorite/favoriteValidation.js");
-const { requireAuth, optionalAuth } = require("@middleware/authMiddleware.js");
+const authValidation = require("@validation/auth/authValidation");
+const webtoonValidation = require("@validation/webtoon/webtoonValidation");
+const episodeValidation = require("@validation/webtoon/episodeValidation");
+const commentValidation = require("@validation/comment/commentValidation");
+const userValidation = require("@validation/user/userValidation");
+const favoriteValidation = require("@validation/favorite/favoriteValidation");
+const { requireAuth, optionalAuth } = require("@middleware/authMiddleware");
 
 
 // 인증(Authentication) API

--- a/app/src/routes/user/userController.js
+++ b/app/src/routes/user/userController.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const UserService = require("@services/user/userService.js");
+const UserService = require("@services/user/userService");
 const userService = new UserService();
-const FavoriteService = require("@services/favorite/favoriteService.js");
+const FavoriteService = require("@services/favorite/favoriteService");
 const favoriteService = new FavoriteService();
 
 module.exports = {

--- a/app/src/services/comment/commentService.js
+++ b/app/src/services/comment/commentService.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const CommentRepository = require("@repositories/comment/commentRepository.js");
+const CommentRepository = require("@repositories/comment/commentRepository");
 const CustomError = require("@utils/customError");
-const EpisodeRepository = require("@repositories/webtoon/episodeRepository.js");
+const EpisodeRepository = require("@repositories/webtoon/episodeRepository");
 
 class CommentService {
   constructor() {

--- a/app/src/services/favorite/favoriteService.js
+++ b/app/src/services/favorite/favoriteService.js
@@ -1,10 +1,10 @@
 "use strict";
 
-const WebtoonRepository = require("@repositories/webtoon/webtoonRepository.js");
-const UserRepository = require("@repositories/user/userRepository.js");
-const FavoriteRepository = require("@repositories/favorite/favoriteRepository.js");
+const WebtoonRepository = require("@repositories/webtoon/webtoonRepository");
+const UserRepository = require("@repositories/user/userRepository");
+const FavoriteRepository = require("@repositories/favorite/favoriteRepository");
 const CustomError = require("@utils/customError");
-const pool = require("@config/db.js");
+const pool = require("@config/db");
 
 class FavoriteService {
   constructor() {

--- a/app/src/services/user/userService.js
+++ b/app/src/services/user/userService.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const UserRepository = require("@repositories/user/userRepository.js");
+const UserRepository = require("@repositories/user/userRepository");
 const CustomError = require("@utils/customError");
 const bcrypt = require("bcrypt");
 

--- a/app/src/services/webtoon/episodeService.js
+++ b/app/src/services/webtoon/episodeService.js
@@ -1,8 +1,8 @@
 "use strict";
 
+const getDb = require("@utils/getDb.js");
 const EpisodeRepository = require("@repositories/webtoon/episodeRepository");
 const CustomError = require("@utils/customError");
-const pool = require("@config/db");
 
 class EpisodeService {
   constructor() {
@@ -31,8 +31,8 @@ class EpisodeService {
       connection = await pool.getConnection();
       await connection.beginTransaction();
 
-      await this.episodeRepository.createRating(connection, userId, episodeId, rating);
-      const stats = await this.episodeRepository.applyNewRating(connection, episodeId, rating);
+      await this.episodeRepository.createRating(userId, episodeId, rating, connection);
+      const stats = await this.episodeRepository.applyNewRating(episodeId, rating, connection);
 
       if (!stats) {
         throw new CustomError("존재하지 않는 에피소드입니다.", 404);

--- a/app/src/services/webtoon/episodeService.js
+++ b/app/src/services/webtoon/episodeService.js
@@ -2,7 +2,7 @@
 
 const EpisodeRepository = require("@repositories/webtoon/episodeRepository");
 const CustomError = require("@utils/customError");
-const pool = require("@config/db.js");
+const pool = require("@config/db");
 
 class EpisodeService {
   constructor() {

--- a/app/src/services/webtoon/episodeService.js
+++ b/app/src/services/webtoon/episodeService.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const getDb = require("@utils/getDb.js");
 const EpisodeRepository = require("@repositories/webtoon/episodeRepository");
 const CustomError = require("@utils/customError");
+const pool = require("@config/db.js");
 
 class EpisodeService {
   constructor() {

--- a/app/src/validation/auth/authValidation.js
+++ b/app/src/validation/auth/authValidation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { body } = require("express-validator");
-const { createValidation } = require("@middleware/validationHelper.js");
+const { createValidation } = require("@middleware/validationHelper");
 
 const checkAddUser = createValidation(
   body("username")

--- a/app/src/validation/comment/commentValidation.js
+++ b/app/src/validation/comment/commentValidation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { body, param } = require("express-validator");
-const { createValidation } = require("@middleware/validationHelper.js");
+const { createValidation } = require("@middleware/validationHelper");
 
 const checkAddComment = createValidation(
   body("content").notEmpty().withMessage("내용을 입력해주세요."),

--- a/app/src/validation/favorite/favoriteValidation.js
+++ b/app/src/validation/favorite/favoriteValidation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { body, query } = require("express-validator");
-const { createValidation } = require("@middleware/validationHelper.js");
+const { createValidation } = require("@middleware/validationHelper");
 
 const checkSortParam = createValidation(
   query("sort")

--- a/app/src/validation/user/userValidation.js
+++ b/app/src/validation/user/userValidation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { body, param, query } = require("express-validator");
-const { createValidation } = require("@middleware/validationHelper.js");
+const { createValidation } = require("@middleware/validationHelper");
 
 const checkNicknameUpdate = createValidation(
   body("newNickname").custom((value) => {

--- a/app/src/validation/webtoon/episodeValidation.js
+++ b/app/src/validation/webtoon/episodeValidation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { body, param } = require("express-validator");
-const { createValidation } = require("@middleware/validationHelper.js");
+const { createValidation } = require("@middleware/validationHelper");
 
 const checkEpisodeIdParam = createValidation(
   param("episodeId")

--- a/app/src/validation/webtoon/webtoonValidation.js
+++ b/app/src/validation/webtoon/webtoonValidation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { query, param } = require("express-validator");
-const { createValidation } = require("@middleware/validationHelper.js");
+const { createValidation } = require("@middleware/validationHelper");
 
 const checkWebtoonQuery = createValidation(
   query("day")


### PR DESCRIPTION
## 연관된 이슈
- #47

## 📝 작업 내용
- [x] getDb 유틸 적용으로 repository의 connection/pool 처리 통일

## 💬 설명
repository 메서드가 optional `conn`을 받도록 수정하고 `getDb` 유틸을 적용하여, 
service에서 트랜잭션 관리가 가능하도록 구조를 개선했습니다. 
`conn`이 없으면 기존처럼 pool을 사용해 호출 방식과 호환성을 유지합니다.