### PR TITLE
fix: (#58) DB와 JSON 반환 시간대 불일치 문제 해결

### DIFF
--- a/app/src/config/db.js
+++ b/app/src/config/db.js
@@ -7,6 +7,7 @@ const db = mysql.createPool({
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
+  timezone: "+00:00",
 });
 
 module.exports = db;


### PR DESCRIPTION
## 연관된 이슈
- #58

## 📝 작업 내용
- [x]  MySQL 연결 시 timezone: "+00:00" 옵션 설정으로 DB와 JSON 반환 시간대 불일치 문제 해결 (UTC 기준 통일)